### PR TITLE
Johannes/json fix

### DIFF
--- a/sc/tw/src/main/scala/threaded/ThreadedStreaming.scala
+++ b/sc/tw/src/main/scala/threaded/ThreadedStreaming.scala
@@ -137,7 +137,7 @@ class BufferedTwitterStream(val streamConfig: StreamConfig) extends TwitterBasic
   def handleDeletion(status: StatusDeletionNotice): Unit = {
     val notice = TweetSchema(
       status.getStatusId,
-      "",
+      "{}",
       0L,
       status.getUserId,
       "deletion"
@@ -163,7 +163,7 @@ class BufferedTwitterStream(val streamConfig: StreamConfig) extends TwitterBasic
     def onScrubGeo(userId: Long, upToStatusId: Long) : Unit = {
       val scrubGeo = TweetSchema(
         upToStatusId,
-        "",
+        "{}",
         0L,
         userId,
         "scrubGeo"

--- a/sc/tw/src/test/scala/ttt/ParseTwitter4jTest.scala
+++ b/sc/tw/src/test/scala/ttt/ParseTwitter4jTest.scala
@@ -27,6 +27,7 @@ class ParseTwitter4jTest extends org.scalatest.funsuite.AnyFunSuite{
                               .text(testFilePath)
                               .collect()
                               .map(x=>x.getString(0))
+                              .filter(x => ujson.read(x)("statusType").str == "status")
                               .map(x=>ujson.read(x)("json").toString)
                                 
                                         


### PR DESCRIPTION
The empty string is not a valid JSON object, now `{}` is used instead.